### PR TITLE
Build Docker images for amd64 and arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Lowercase Repository Name
         id: repository
         uses: Entepotenz/change-string-case-action-min-dependencies@v1
@@ -35,6 +41,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ steps.repository.outputs.lowercase }}:${{ github.ref_name }}
             ghcr.io/${{ steps.repository.outputs.lowercase }}:latest
@@ -46,6 +53,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ steps.repository.outputs.lowercase }}:${{ github.sha }}
             ghcr.io/${{ steps.repository.outputs.lowercase }}:latest


### PR DESCRIPTION
## Summary
- enable Docker Buildx with QEMU to cross-build images
- publish multi-architecture images for linux/amd64 and linux/arm64 on pushes and tags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19f71dc5c83319237aea5db3269c6